### PR TITLE
My adjustments. Main one is the on_construct usage

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -4,12 +4,13 @@ local MAX = 20000
 local DEBUG = false
 local HSPACING = 4
 local VSPACING = 5
-local CHEST_CHANCE = 0.9
 local SPAWNS = math.floor(31000/HSPACING/2)
 
 local groups_ignore = {
     --"tnt",
     --"igniter"
+	"not_in_creative_inventory",
+	"bed"
 }
 
 gen = {}
@@ -18,17 +19,12 @@ gen.items = {}
 
 function gen.ignore(name, props)
     local ignore = false
-
     for _, ignored_group in ipairs(groups_ignore) do
-        for actual_group, val in pairs(props.groups) do
-            if actual_group == ignored_group then
-                print("ignoring " .. tostring(name))
-                ignore = true
-            end
+        if props.groups[ignored_group] then
+--          print("ignoring " .. tostring(name))
+            return true
         end
     end
-
-    return ignore
 end
 
 minetest.after(0, function()
@@ -60,24 +56,7 @@ end
 -- fill chests
 function gen.fill_chest(pos)
     local meta = minetest.get_meta(pos)
-
-    local chest_formspec =
-     "size[8,9]" ..
-     default.gui_bg ..
-     default.gui_bg_img ..
-     default.gui_slots ..
-     "list[current_name;main;0,0.3;8,4;]" ..
-     "list[current_player;main;0,4.85;8,1;]" ..
-     "list[current_player;main;0,6.08;8,3;8]" ..
-     "listring[current_name;main]" ..
-     "listring[current_player;main]" ..
-     default.get_hotbar_bg(0,4.85)
-    
-    meta:set_string("formspec", chest_formspec)
-    meta:set_string("infotext", "Chest")
     local inv = meta:get_inventory()
-    inv:set_size("main", 8*4)
-
     -- fill inventory
     for i = 1,math.random(32) do
         inv:add_item("main", gen.get_item() .. " " .. tostring(math.random(99)))
@@ -98,15 +77,17 @@ minetest.register_on_generated(function(minp, maxp, seed)
 	local vm, emin, emax = minetest.get_mapgen_object("voxelmanip")
 	local data = vm:get_data()
 	local area = VoxelArea:new{MinEdge=emin, MaxEdge=emax}
+	local on_construct_tab = {}
 
 	for x=minp.x,maxp.x do
 		for z=minp.z,maxp.z do
 			for y=minp.y,maxp.y do
                 if x % HSPACING == 0 and z % HSPACING == 0 and y % VSPACING == 0 then
                     local node = gen.get_node()
+                    local pos = {x=x,y=y,z=z}
                     data[area:index(x, y, z)] = minetest.get_content_id(node)
-                    if math.random() > CHEST_CHANCE then
-                        gen.fill_chest({x=x,y=y,z=z})
+                    if minetest.registered_nodes[node].on_construct then
+                        on_construct_tab[pos] = node
                     end
                 end
 			end
@@ -121,6 +102,18 @@ minetest.register_on_generated(function(minp, maxp, seed)
 	vm:calc_lighting()
 	vm:update_liquids()
 	vm:write_to_map()
+
+	-- fix the nodes
+	if next(on_construct_tab) then
+		minetest.after(0.2, function(on_construct_tab)
+			for pos, node in pairs(on_construct_tab) do
+				minetest.registered_nodes[node].on_construct(pos)
+				if node == 'default:chest' then
+					minetest.after(0, gen.fill_chest, pos)
+				end
+			end
+		end, on_construct_tab)
+	end
 
 	local t3 = os.clock()
 	local geninfo = "[mg] done after ca.: "..calcdelay.." + "..string.format("%.2fs", t3 - t2).." = "..string.format("%.2fs", t3 - t1)


### PR DESCRIPTION
- Initialize nodes by on_construct
- Remove own chest formspec, because done by on_construct now
- code optimization in get.ignore (loop avoided)
- Fill chest if the chest is selected by gen.get_node()
- not_in_creative_inventory excluded by default - technical nodes that should not be placed arbitrarily
- bed excluded by default - needs on_place initialization with user. Without it is just a half-bed